### PR TITLE
Error in subject.roles.all

### DIFF
--- a/lib/aclatraz/suspect.rb
+++ b/lib/aclatraz/suspect.rb
@@ -57,7 +57,7 @@ module Aclatraz
       #   suspect.roles.assign(:bar)
       #   suspect.roles.all # => ["foo", "bar"]
       def all
-        Aclatraz.store.roles(self)
+        Aclatraz.store.roles(suspect)
       end
       alias_method :list, :all
     end # Roles


### PR DESCRIPTION
Calling subject.roles.all results in the following error message:

undefined method `id' for #Aclatraz::Suspect::Roles:0x00000002a8b158

The attached patch fixes the error. The spec however still remains broken since the roles in the store do not match the expected roles for some reason. It seems to me as if the store is not properly purged before running the case and some roles remain in the store after other, unrelated test runs.
